### PR TITLE
Card popup menu

### DIFF
--- a/Assets/Utility/Managers/experience_manager.gd
+++ b/Assets/Utility/Managers/experience_manager.gd
@@ -22,4 +22,5 @@ func on_experience_collected(number_of_experience: int):
 	current_points += number_of_experience
 	while current_points >= points_to_levelup:
 		level_up()
+		await GameEvents.upgrade_selected
 	GameEvents.emit_update_experience_bar(current_points, points_to_levelup, current_level)

--- a/Assets/Utility/Managers/experience_manager.gd
+++ b/Assets/Utility/Managers/experience_manager.gd
@@ -4,6 +4,7 @@ extends Node
 var current_points = 0
 var current_level = 1
 
+signal level_up_signal
 
 func _ready():
 	GameEvents.experience_collected.connect(on_experience_collected)
@@ -14,6 +15,7 @@ func level_up():
 	current_points -= points_to_levelup
 	current_level += 1
 	points_to_levelup += 5
+	level_up_signal.emit()
 
 	
 func on_experience_collected(number_of_experience: int):

--- a/Assets/Utility/Managers/experience_manager.gd
+++ b/Assets/Utility/Managers/experience_manager.gd
@@ -15,6 +15,7 @@ func level_up():
 	current_points -= points_to_levelup
 	current_level += 1
 	points_to_levelup += 5
+	get_tree().paused = true
 	level_up_signal.emit()
 
 	

--- a/Assets/Utility/Managers/upgrade_manager.gd
+++ b/Assets/Utility/Managers/upgrade_manager.gd
@@ -11,5 +11,5 @@ func _ready():
 func on_level_up_signal():
 	var level_up_menu_instance = level_up_menu.instantiate()
 	add_child(level_up_menu_instance)
-	print("Stworzono karty")
+	
 

--- a/Assets/Utility/Managers/upgrade_manager.gd
+++ b/Assets/Utility/Managers/upgrade_manager.gd
@@ -1,0 +1,15 @@
+extends Node
+
+@export var experience_manager: Node
+var level_up_menu = preload("res://Assets/Utility/UI/LvlUps/CardPopupMenu.tscn")
+
+
+func _ready():
+	experience_manager.level_up_signal.connect(on_level_up_signal)
+	
+	
+func on_level_up_signal():
+	var level_up_menu_instance = level_up_menu.instantiate()
+	add_child(level_up_menu_instance)
+	print("Stworzono karty")
+

--- a/Assets/Utility/Managers/upgrade_manager.tscn
+++ b/Assets/Utility/Managers/upgrade_manager.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://b8xmmtnaynmte"]
+
+[ext_resource type="Script" path="res://Assets/Utility/Managers/upgrade_manager.gd" id="1_j5l6r"]
+
+[node name="upgrade_manager" type="Node"]
+script = ExtResource("1_j5l6r")

--- a/Assets/Utility/UI/LvlUps/CardPopupMenu.gd
+++ b/Assets/Utility/UI/LvlUps/CardPopupMenu.gd
@@ -1,0 +1,12 @@
+extends CanvasLayer
+
+var level_up_card = preload("res://Assets/Utility/UI/LvlUps/LvlUpCard.tscn")
+@onready var h_box_container = $MarginContainer/HBoxContainer
+
+
+func _ready():
+	get_tree().paused = true
+	for i in range(3):
+		var level_up_card_instance = level_up_card.instantiate()
+		level_up_card_instance.parent_panel = self
+		h_box_container.add_child(level_up_card_instance)

--- a/Assets/Utility/UI/LvlUps/CardPopupMenu.gd
+++ b/Assets/Utility/UI/LvlUps/CardPopupMenu.gd
@@ -5,7 +5,6 @@ var level_up_card = preload("res://Assets/Utility/UI/LvlUps/LvlUpCard.tscn")
 
 
 func _ready():
-	
 	get_tree().paused = true
 	for i in range(3):
 		var level_up_card_instance = level_up_card.instantiate()

--- a/Assets/Utility/UI/LvlUps/CardPopupMenu.gd
+++ b/Assets/Utility/UI/LvlUps/CardPopupMenu.gd
@@ -10,3 +10,4 @@ func _ready():
 		var level_up_card_instance = level_up_card.instantiate()
 		level_up_card_instance.parent_panel = self
 		h_box_container.add_child(level_up_card_instance)
+	await GameEvents.upgrade_selected

--- a/Assets/Utility/UI/LvlUps/CardPopupMenu.gd
+++ b/Assets/Utility/UI/LvlUps/CardPopupMenu.gd
@@ -5,6 +5,7 @@ var level_up_card = preload("res://Assets/Utility/UI/LvlUps/LvlUpCard.tscn")
 
 
 func _ready():
+	
 	get_tree().paused = true
 	for i in range(3):
 		var level_up_card_instance = level_up_card.instantiate()

--- a/Assets/Utility/UI/LvlUps/CardPopupMenu.tscn
+++ b/Assets/Utility/UI/LvlUps/CardPopupMenu.tscn
@@ -1,0 +1,25 @@
+[gd_scene load_steps=2 format=3 uid="uid://cmcckr2drb51t"]
+
+[ext_resource type="Script" path="res://Assets/Utility/UI/LvlUps/CardPopupMenu.gd" id="1_rdosj"]
+
+[node name="CardPopupMenu" type="CanvasLayer"]
+process_mode = 3
+script = ExtResource("1_rdosj")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 8
+theme_override_constants/margin_top = 8
+theme_override_constants/margin_right = 8
+theme_override_constants/margin_bottom = 8
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_constants/separation = 10
+alignment = 1

--- a/Assets/Utility/UI/LvlUps/LvlUpCard.gd
+++ b/Assets/Utility/UI/LvlUps/LvlUpCard.gd
@@ -1,0 +1,23 @@
+extends PanelContainer
+
+var parent_panel
+
+func _ready():
+	gui_input.connect(on_input_gui)
+	mouse_entered.connect(on_mouse_entered)
+	
+	
+func select_card():
+	get_tree().paused = false
+	GameEvents.emit_upgrade_selected()
+	parent_panel.queue_free()
+	
+
+func on_input_gui(event: InputEvent):
+	if event.is_action_pressed("left_click"):
+		select_card()
+
+	
+	
+func on_mouse_entered():
+	pass

--- a/Assets/Utility/UI/LvlUps/LvlUpCard.gd
+++ b/Assets/Utility/UI/LvlUps/LvlUpCard.gd
@@ -3,19 +3,25 @@ extends PanelContainer
 @onready var animation_player = $AnimationPlayer
 
 var parent_panel
+var disabled = true
 
 func _ready():
 	gui_input.connect(on_input_gui)
 	mouse_entered.connect(on_mouse_entered)
+	mouse_exited.connect(on_mouse_exited)
+	modulate = Color.TRANSPARENT
 	animation_player.play("in")
-	
-	
-func play_out_animation():
-	animation_player.play_backwards("in")
+	await animation_player.animation_finished
+	disabled = false
 
 	
 func select_card():
-	animation_player.play_backwards("in")
+	disabled = true
+	for card in get_parent().get_children():
+		if card == self:
+			continue
+		card.animation_player.play("out")
+	animation_player.play("out")
 	await animation_player.animation_finished
 	get_tree().paused = false
 	GameEvents.emit_upgrade_selected()
@@ -23,10 +29,21 @@ func select_card():
 	
 
 func on_input_gui(event: InputEvent):
+	modulate = Color.WHITE
 	if event.is_action_pressed("left_click"):
 		select_card()
 
 	
 	
 func on_mouse_entered():
-	pass
+	modulate = Color.WHITE
+	if disabled:
+		return
+	animation_player.play("hover")
+
+
+func on_mouse_exited():
+	modulate = Color.WHITE
+	if disabled:
+		return
+	animation_player.play_backwards("hover")

--- a/Assets/Utility/UI/LvlUps/LvlUpCard.gd
+++ b/Assets/Utility/UI/LvlUps/LvlUpCard.gd
@@ -1,13 +1,22 @@
 extends PanelContainer
 
+@onready var animation_player = $AnimationPlayer
+
 var parent_panel
 
 func _ready():
 	gui_input.connect(on_input_gui)
 	mouse_entered.connect(on_mouse_entered)
+	animation_player.play("in")
 	
+	
+func play_out_animation():
+	animation_player.play_backwards("in")
+
 	
 func select_card():
+	animation_player.play_backwards("in")
+	await animation_player.animation_finished
 	get_tree().paused = false
 	GameEvents.emit_upgrade_selected()
 	parent_panel.queue_free()

--- a/Assets/Utility/UI/LvlUps/LvlUpCard.tscn
+++ b/Assets/Utility/UI/LvlUps/LvlUpCard.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=3 uid="uid://0lki8syiju0y"]
+[gd_scene load_steps=19 format=3 uid="uid://0lki8syiju0y"]
 
 [ext_resource type="Texture2D" uid="uid://0fg5jy6em8v" path="res://Assets/Utility/UI/LvlUps/Textures/label-frame.png" id="1_x7dl0"]
 [ext_resource type="Texture2D" uid="uid://bohp5co365dr" path="res://Assets/Utility/UI/LvlUps/Textures/Lvl-up-uncommon-frame.png" id="2_jaheu"]
@@ -75,6 +75,18 @@ tracks/0/keys = {
 "update": 0,
 "values": [Vector2(1, 1)]
 }
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath(".:modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
+}
 
 [sub_resource type="Animation" id="Animation_w5orx"]
 resource_name = "in"
@@ -92,13 +104,56 @@ tracks/0/keys = {
 "update": 0,
 "values": [Vector2(0, 0), Vector2(1, 1)]
 }
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath(".:modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
+}
 
 [sub_resource type="Animation" id="Animation_2jhur"]
 resource_name = "out"
+length = 0.4
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:scale")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.4),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(1, 1), Vector2(0, 0)]
+}
+
+[sub_resource type="Animation" id="Animation_xrfty"]
+resource_name = "hover"
+length = 0.4
+step = 0.05
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:scale")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.4),
+"transitions": PackedFloat32Array(1, 2.54912),
+"update": 0,
+"values": [Vector2(1, 1), Vector2(1.2, 1.2)]
+}
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_0exjo"]
 _data = {
 "RESET": SubResource("Animation_q04jn"),
+"hover": SubResource("Animation_xrfty"),
 "in": SubResource("Animation_w5orx"),
 "out": SubResource("Animation_2jhur")
 }
@@ -116,9 +171,11 @@ libraries = {
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
+mouse_filter = 2
 
 [node name="MarginContainer3" type="MarginContainer" parent="VBoxContainer"]
 layout_mode = 2
+mouse_filter = 2
 theme_type_variation = &"LvlUpMarginContainer"
 theme_override_constants/margin_top = 10
 
@@ -126,10 +183,12 @@ theme_override_constants/margin_top = 10
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
+mouse_filter = 2
 texture = ExtResource("2_xfo3i")
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer"]
 layout_mode = 2
+mouse_filter = 2
 theme_type_variation = &"LvlUpMarginContainer"
 theme_override_constants/margin_left = 25
 theme_override_constants/margin_top = 2
@@ -148,6 +207,7 @@ vertical_alignment = 1
 
 [node name="MarginContainer2" type="MarginContainer" parent="VBoxContainer"]
 layout_mode = 2
+mouse_filter = 2
 theme_type_variation = &"LvlUpMarginContainer"
 theme_override_constants/margin_left = 10
 theme_override_constants/margin_right = 10

--- a/Assets/Utility/UI/LvlUps/LvlUpCard.tscn
+++ b/Assets/Utility/UI/LvlUps/LvlUpCard.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=3 uid="uid://0lki8syiju0y"]
+[gd_scene load_steps=14 format=3 uid="uid://0lki8syiju0y"]
 
 [ext_resource type="Texture2D" uid="uid://0fg5jy6em8v" path="res://Assets/Utility/UI/LvlUps/Textures/label-frame.png" id="1_x7dl0"]
 [ext_resource type="Texture2D" uid="uid://bohp5co365dr" path="res://Assets/Utility/UI/LvlUps/Textures/Lvl-up-uncommon-frame.png" id="2_jaheu"]
@@ -6,6 +6,7 @@
 [ext_resource type="Texture2D" uid="uid://dj7k70hfr0n2m" path="res://Assets/Utility/UI/LvlUps/Textures/Lvl-up-epic-frame.png" id="3_qd0t6"]
 [ext_resource type="Texture2D" uid="uid://du6ax6dfsf5dt" path="res://Assets/Utility/UI/LvlUps/Textures/Lvl-up-legendary-frame.png" id="4_n3wkc"]
 [ext_resource type="Texture2D" uid="uid://bnic1icsl1vfk" path="res://Assets/Utility/UI/LvlUps/Textures/Lvl-up-rare-frame.png" id="5_ijf2t"]
+[ext_resource type="Script" path="res://Assets/Utility/UI/LvlUps/LvlUpCard.gd" id="6_fomnb"]
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_fx81u"]
 texture = ExtResource("1_x7dl0")
@@ -63,6 +64,7 @@ PanelContainerRare/styles/panel = SubResource("StyleBoxTexture_y0455")
 [node name="Card" type="PanelContainer"]
 custom_minimum_size = Vector2(170, 260)
 theme = SubResource("Theme_4g5up")
+script = ExtResource("6_fomnb")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2

--- a/Assets/Utility/UI/LvlUps/LvlUpCard.tscn
+++ b/Assets/Utility/UI/LvlUps/LvlUpCard.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://0lki8syiju0y"]
+[gd_scene load_steps=18 format=3 uid="uid://0lki8syiju0y"]
 
 [ext_resource type="Texture2D" uid="uid://0fg5jy6em8v" path="res://Assets/Utility/UI/LvlUps/Textures/label-frame.png" id="1_x7dl0"]
 [ext_resource type="Texture2D" uid="uid://bohp5co365dr" path="res://Assets/Utility/UI/LvlUps/Textures/Lvl-up-uncommon-frame.png" id="2_jaheu"]
@@ -61,10 +61,58 @@ PanelContainerLegendary/styles/panel = SubResource("StyleBoxTexture_iamk3")
 PanelContainerRare/base_type = &"PanelContainer"
 PanelContainerRare/styles/panel = SubResource("StyleBoxTexture_y0455")
 
-[node name="Card" type="PanelContainer"]
+[sub_resource type="Animation" id="Animation_q04jn"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:scale")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(1, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_w5orx"]
+resource_name = "in"
+length = 0.4
+step = 0.05
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:scale")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.4),
+"transitions": PackedFloat32Array(1, 2.92817),
+"update": 0,
+"values": [Vector2(0, 0), Vector2(1, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_2jhur"]
+resource_name = "out"
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_0exjo"]
+_data = {
+"RESET": SubResource("Animation_q04jn"),
+"in": SubResource("Animation_w5orx"),
+"out": SubResource("Animation_2jhur")
+}
+
+[node name="Card" type="PanelContainer" groups=["upgrade_card"]]
 custom_minimum_size = Vector2(170, 260)
+pivot_offset = Vector2(85, 130)
 theme = SubResource("Theme_4g5up")
 script = ExtResource("6_fomnb")
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_0exjo")
+}
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2

--- a/Assets/World/game_events.gd
+++ b/Assets/World/game_events.gd
@@ -2,6 +2,7 @@ extends Node
 
 signal experience_collected(number_of_experience: int)
 signal update_experience_bar(current_points: int, points_to_level_up: int, current_level: int)
+signal upgrade_selected
 
 
 func emit_experience_collected(number_of_experience: int):
@@ -10,3 +11,7 @@ func emit_experience_collected(number_of_experience: int):
 
 func emit_update_experience_bar(current_points: int, points_to_level_up: int, current_level: int):
 	update_experience_bar.emit(current_points, points_to_level_up, current_level)
+
+
+func emit_upgrade_selected():
+	upgrade_selected.emit()

--- a/Assets/World/world.tscn
+++ b/Assets/World/world.tscn
@@ -188,7 +188,7 @@ position = Vector2(-553, -100)
 [node name="ItemsLayer" type="Node" parent="." groups=["items"]]
 
 [node name="ExperienceCollectPickup" parent="ItemsLayer" instance=ExtResource("27_nkgxi")]
-position = Vector2(-26, -9)
+position = Vector2(-155, -32)
 
 [node name="MovementSpeedpickup" parent="ItemsLayer" instance=ExtResource("25_3o6nv")]
 position = Vector2(-31, 51)

--- a/Assets/World/world.tscn
+++ b/Assets/World/world.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=29 format=3 uid="uid://b11rms50550mc"]
+[gd_scene load_steps=32 format=3 uid="uid://b11rms50550mc"]
 
 [ext_resource type="Texture2D" uid="uid://cyk70kc581cr8" path="res://Assets/Tutorial/dirt_full_new.png" id="1_taj5e"]
 [ext_resource type="PackedScene" uid="uid://iupuujdctspl" path="res://Assets/Player/player.tscn" id="2_j8yv2"]
@@ -23,7 +23,10 @@
 [ext_resource type="PackedScene" uid="uid://c23nv1wariral" path="res://Assets/World/Environment/Scen/stone_2e.tscn" id="18_gh0ig"]
 [ext_resource type="PackedScene" uid="uid://bvawrv4cvkx6q" path="res://Assets/Utility/Managers/experience_manager.tscn" id="22_c4rh6"]
 [ext_resource type="PackedScene" uid="uid://b12g08nqirib2" path="res://Assets/Utility/UI/Progressbar/progress_bar.tscn" id="23_gh6bk"]
+[ext_resource type="PackedScene" uid="uid://c36cdmngcpuic" path="res://Assets/Utility/DropItems/Crystals/CrystalGreen.tscn" id="24_al4of"]
 [ext_resource type="PackedScene" uid="uid://ctx7i4wkn20wl" path="res://Assets/Utility/DropItems/MovementSpeedPickup/MovementSpeedPickup.tscn" id="25_3o6nv"]
+[ext_resource type="PackedScene" uid="uid://dign3j2sdr85j" path="res://Assets/Utility/DropItems/Crystals/CrystalRed.tscn" id="25_te5lv"]
+[ext_resource type="PackedScene" uid="uid://b8xmmtnaynmte" path="res://Assets/Utility/Managers/upgrade_manager.tscn" id="26_etwnf"]
 [ext_resource type="PackedScene" uid="uid://jbk4o4vuchg8" path="res://Assets/Utility/UI/LvlUps/LvlUps.tscn" id="26_ntv7e"]
 [ext_resource type="PackedScene" uid="uid://dnul08gmjwq6" path="res://Assets/Utility/DropItems/ExperienceCollectPickup/ExperienceCollectPickup.tscn" id="27_nkgxi"]
 
@@ -184,15 +187,39 @@ position = Vector2(-553, -100)
 
 [node name="ItemsLayer" type="Node" parent="." groups=["items"]]
 
+[node name="ExperienceCollectPickup" parent="ItemsLayer" instance=ExtResource("27_nkgxi")]
+position = Vector2(-26, -9)
+
+[node name="MovementSpeedpickup" parent="ItemsLayer" instance=ExtResource("25_3o6nv")]
+position = Vector2(-31, 51)
+
+[node name="ExperienceCrystal" parent="ItemsLayer" instance=ExtResource("24_al4of")]
+position = Vector2(26, -73)
+
+[node name="ExperienceCrystal2" parent="ItemsLayer" instance=ExtResource("24_al4of")]
+position = Vector2(62, -53)
+
+[node name="ExperienceCrystal3" parent="ItemsLayer" instance=ExtResource("24_al4of")]
+position = Vector2(87, -28)
+
+[node name="ExperienceCrystal4" parent="ItemsLayer" instance=ExtResource("24_al4of")]
+position = Vector2(87, -28)
+
+[node name="ExperienceCrystal5" parent="ItemsLayer" instance=ExtResource("24_al4of")]
+position = Vector2(106, -3)
+
+[node name="ExperienceCrystal6" parent="ItemsLayer" instance=ExtResource("24_al4of")]
+position = Vector2(107, 30)
+
+[node name="ExperienceCrystal7" parent="ItemsLayer" instance=ExtResource("25_te5lv")]
+position = Vector2(59, 52)
+
 [node name="progress_bar" parent="." instance=ExtResource("23_gh6bk")]
 
 [node name="ExperienceManager" parent="." instance=ExtResource("22_c4rh6")]
 
-[node name="ExperienceCollectPickup" parent="." instance=ExtResource("27_nkgxi")]
-position = Vector2(-26, -9)
-
-[node name="MovementSpeedpickup" parent="." instance=ExtResource("25_3o6nv")]
-position = Vector2(-31, 51)
+[node name="upgrade_manager" parent="." node_paths=PackedStringArray("experience_manager") instance=ExtResource("26_etwnf")]
+experience_manager = NodePath("../ExperienceManager")
 
 [node name="LvlUps" parent="." instance=ExtResource("26_ntv7e")]
 visible = false

--- a/MOT Docs/Docs/UI/CardPopupMenu.md
+++ b/MOT Docs/Docs/UI/CardPopupMenu.md
@@ -1,0 +1,6 @@
+UI element that displays upgrade cards. On `_ready()` function CardPopupMenu creates 3 cards and attaches them to h_box_container.
+
+|Field type|Field name|Description|
+|---|---|---|
+|`preloaded scene`|`level_up_card`|card scene|
+|`preload HBoxContainer`|`h_box_container`|parent of cards|

--- a/MOT Docs/Docs/UI/upgrade_manager.md
+++ b/MOT Docs/Docs/UI/upgrade_manager.md
@@ -1,0 +1,9 @@
+Manager is a Node listening for `level_up_signal` signal. When signal happens, `CardPopupMenu.tscn` is being created.
+
+|Field type|Field name|Description|
+|---|---|---|
+|`Node`|`experience_manager`|manager responsible for sending `level_up_signal`|
+|`preloaded scene`|`level_up_menu`|menu scene which will be created in `on_level_up_signal` function|
+
+Functions:
+- `on_level_up_signal()` - creates menu for card display (void).

--- a/project.godot
+++ b/project.godot
@@ -64,6 +64,11 @@ DEBUG_manual_heal={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"echo":false,"script":null)
 ]
 }
+left_click={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":1,"position":Vector2(94, 14),"global_position":Vector2(98, 57),"factor":1.0,"button_index":1,"canceled":false,"pressed":true,"double_click":false,"script":null)
+]
+}
 
 [layer_names]
 


### PR DESCRIPTION
When player reaches new level, CardPopupMenu is created. This menu contains 3 upgrade cards (for now static placeholders) from which the player can choose one.

![image](https://github.com/AGH-Code-Industry/monstrous-tide/assets/60001858/72a43ebd-f2b7-4ba1-8781-b9207df2afad)
