### PR TITLE
Reroll upgrade ability

### DIFF
--- a/Assets/Utility/Managers/weapon_manager.gd
+++ b/Assets/Utility/Managers/weapon_manager.gd
@@ -24,6 +24,9 @@ func get_all_upgrades():
 func get_randomly_chosen_upgrades(amount: int, avoided_upgrades = []):
 	# Geting upgrades from each weapon
 	var all_upgrades = get_all_upgrades()
+	for avoid_upgrade in avoided_upgrades:
+		if avoid_upgrade in all_upgrades:
+			all_upgrades.erase(avoid_upgrade)
 	# Checking if array of upgrades is empty	
 	if all_upgrades.size() == 0:
 		return	
@@ -38,9 +41,6 @@ func get_randomly_chosen_upgrades(amount: int, avoided_upgrades = []):
 		var offset: float = 0
 		for upgrade in all_upgrades:
 			if random_number < upgrade.weight + offset:
-				if upgrade in avoided_upgrades:
-#					offset += upgrade.weight
-					continue
 				drawn_upgrades.append(upgrade)
 				all_upgrades.erase(upgrade)
 				break

--- a/Assets/Utility/Managers/weapon_manager.gd
+++ b/Assets/Utility/Managers/weapon_manager.gd
@@ -14,14 +14,17 @@ func _ready() -> void:
 			weapons.append(node)
 
 
-# returns specified amount of upgrades chosen randomly 
-func get_randomly_chosen_upgrades(amount: int):
-	# Geting upgrades from each weapon
+func get_all_upgrades():
 	var all_upgrades = []
 	for weapon in weapons:
 		all_upgrades.append_array(weapon.get_available_upgrades())
-	# Checking if array of upgrades is empty
-	print(all_upgrades)		
+	return all_upgrades
+
+# returns specified amount of upgrades chosen randomly 
+func get_randomly_chosen_upgrades(amount: int, avoided_upgrades = []):
+	# Geting upgrades from each weapon
+	var all_upgrades = get_all_upgrades()
+	# Checking if array of upgrades is empty	
 	if all_upgrades.size() == 0:
 		return	
 	# Array for drawn upgrades
@@ -35,6 +38,9 @@ func get_randomly_chosen_upgrades(amount: int):
 		var offset: float = 0
 		for upgrade in all_upgrades:
 			if random_number < upgrade.weight + offset:
+				if upgrade in avoided_upgrades:
+#					offset += upgrade.weight
+					continue
 				drawn_upgrades.append(upgrade)
 				all_upgrades.erase(upgrade)
 				break

--- a/Assets/Utility/UI/LvlUps/CardPopupMenu.gd
+++ b/Assets/Utility/UI/LvlUps/CardPopupMenu.gd
@@ -1,7 +1,7 @@
 extends CanvasLayer
 
 @onready var h_box_container = $MarginContainer/HBoxContainer
-@export var cards_to_draw_count = 4
+@export var cards_to_draw_count = 3
 var level_up_card = preload("res://Assets/Utility/UI/LvlUps/LvlUpCard.tscn")
 var WeaponManager: Node
 var current_upgrades
@@ -28,7 +28,7 @@ func remove_cards():
 	for card in h_box_container.get_children():
 		card.queue_free()
 	if len(WeaponManager.get_all_upgrades()) - len(current_upgrades) <= 0:
-		$MarginContainer/Button.disabled = true
+		%RerollButton.disabled = true
 	visible = false
 
 
@@ -45,7 +45,7 @@ func level_up(levels_to_lvlup: int):
 		get_tree().paused = false
 
 
-func _on_button_pressed():
+func _on_reroll_button_pressed():
 	var upgrades_left_count = len(WeaponManager.get_all_upgrades()) - len(current_upgrades)
 	if !(upgrades_left_count > len(current_upgrades)):
 		while (len(current_upgrades) - upgrades_left_count):

--- a/Assets/Utility/UI/LvlUps/CardPopupMenu.gd
+++ b/Assets/Utility/UI/LvlUps/CardPopupMenu.gd
@@ -1,7 +1,7 @@
 extends CanvasLayer
 
 @onready var h_box_container = $MarginContainer/HBoxContainer
-@export var cards_to_draw_count = 3
+@export var cards_to_draw_count = 4
 var level_up_card = preload("res://Assets/Utility/UI/LvlUps/LvlUpCard.tscn")
 var WeaponManager: Node
 var current_upgrades
@@ -22,8 +22,6 @@ func create_cards(avoided_upgrades = []):
 		level_up_card_instance.get_node("%ItemDescription").text = str(upgrade.description)
 		
 		h_box_container.add_child(level_up_card_instance)
-	print("All upgrades: " + str(len(WeaponManager.get_all_upgrades())))
-	print("Current upgrades: " + str(len(current_upgrades)))
 		
 		
 func remove_cards():
@@ -49,15 +47,8 @@ func level_up(levels_to_lvlup: int):
 
 func _on_button_pressed():
 	var upgrades_left_count = len(WeaponManager.get_all_upgrades()) - len(current_upgrades)
-	if upgrades_left_count < len(current_upgrades):
-		print(upgrades_left_count)
-		for i in range(len(current_upgrades) - upgrades_left_count):
-			print("Test")
-	match upgrades_left_count:
-		1:
-			current_upgrades.remove_at(len(current_upgrades)-1)
-			current_upgrades.remove_at(len(current_upgrades)-1)
-		2:
+	if !(upgrades_left_count > len(current_upgrades)):
+		while (len(current_upgrades) - upgrades_left_count):
 			current_upgrades.remove_at(len(current_upgrades)-1)
 	remove_cards()
 	create_cards(current_upgrades)

--- a/Assets/Utility/UI/LvlUps/CardPopupMenu.gd
+++ b/Assets/Utility/UI/LvlUps/CardPopupMenu.gd
@@ -3,16 +3,18 @@ extends CanvasLayer
 @onready var h_box_container = $MarginContainer/HBoxContainer
 var level_up_card = preload("res://Assets/Utility/UI/LvlUps/LvlUpCard.tscn")
 var WeaponManager: Node
+var current_upgrades
 
 
-func create_cards():
+func create_cards(avoided_upgrades = []):
+	visible = true
 	if WeaponManager == null:
 		return
-	var all_upgrades = WeaponManager.get_randomly_chosen_upgrades(3)
-	if all_upgrades == null:
+	current_upgrades = WeaponManager.get_randomly_chosen_upgrades(3, avoided_upgrades)
+	if current_upgrades == null:
 		get_tree().paused = false
 		return
-	for upgrade in all_upgrades:
+	for upgrade in current_upgrades:
 		var level_up_card_instance = level_up_card.instantiate()
 		level_up_card_instance.upgrade = upgrade
 		level_up_card_instance.get_node("%ItemName").text = str(upgrade.name)
@@ -24,14 +26,25 @@ func create_cards():
 func remove_cards():
 	for card in h_box_container.get_children():
 		card.queue_free()
-
+	visible = false
+#	$MarginContainer/Button.visible = false
 
 func level_up(levels_to_lvlup: int):
 	if len(h_box_container.get_children()) > 0:
 		await GameEvents.upgrade_selected
 	for i in levels_to_lvlup:
+		if len(WeaponManager.get_all_upgrades()) == 0:
+			return
 		get_tree().paused = true
 		create_cards()
 		await GameEvents.upgrade_selected
 		remove_cards()
 		get_tree().paused = false
+
+
+func _on_button_pressed():
+	print(len(WeaponManager.get_all_upgrades()) - len(current_upgrades))
+	if len(WeaponManager.get_all_upgrades()) - len(current_upgrades) < 3:
+		return
+	remove_cards()
+	create_cards(current_upgrades)

--- a/Assets/Utility/UI/LvlUps/CardPopupMenu.gd
+++ b/Assets/Utility/UI/LvlUps/CardPopupMenu.gd
@@ -1,6 +1,7 @@
 extends CanvasLayer
 
 @onready var h_box_container = $MarginContainer/HBoxContainer
+@export var cards_to_draw_count = 3
 var level_up_card = preload("res://Assets/Utility/UI/LvlUps/LvlUpCard.tscn")
 var WeaponManager: Node
 var current_upgrades
@@ -10,7 +11,7 @@ func create_cards(avoided_upgrades = []):
 	visible = true
 	if WeaponManager == null:
 		return
-	current_upgrades = WeaponManager.get_randomly_chosen_upgrades(3, avoided_upgrades)
+	current_upgrades = WeaponManager.get_randomly_chosen_upgrades(cards_to_draw_count, avoided_upgrades)
 	if current_upgrades == null:
 		get_tree().paused = false
 		return
@@ -21,13 +22,17 @@ func create_cards(avoided_upgrades = []):
 		level_up_card_instance.get_node("%ItemDescription").text = str(upgrade.description)
 		
 		h_box_container.add_child(level_up_card_instance)
+	print("All upgrades: " + str(len(WeaponManager.get_all_upgrades())))
+	print("Current upgrades: " + str(len(current_upgrades)))
 		
 		
 func remove_cards():
 	for card in h_box_container.get_children():
 		card.queue_free()
+	if len(WeaponManager.get_all_upgrades()) - len(current_upgrades) <= 0:
+		$MarginContainer/Button.disabled = true
 	visible = false
-#	$MarginContainer/Button.visible = false
+
 
 func level_up(levels_to_lvlup: int):
 	if len(h_box_container.get_children()) > 0:
@@ -43,8 +48,16 @@ func level_up(levels_to_lvlup: int):
 
 
 func _on_button_pressed():
-	print(len(WeaponManager.get_all_upgrades()) - len(current_upgrades))
-	if len(WeaponManager.get_all_upgrades()) - len(current_upgrades) < 3:
-		return
+	var upgrades_left_count = len(WeaponManager.get_all_upgrades()) - len(current_upgrades)
+	if upgrades_left_count < len(current_upgrades):
+		print(upgrades_left_count)
+		for i in range(len(current_upgrades) - upgrades_left_count):
+			print("Test")
+	match upgrades_left_count:
+		1:
+			current_upgrades.remove_at(len(current_upgrades)-1)
+			current_upgrades.remove_at(len(current_upgrades)-1)
+		2:
+			current_upgrades.remove_at(len(current_upgrades)-1)
 	remove_cards()
 	create_cards(current_upgrades)

--- a/Assets/Utility/UI/LvlUps/CardPopupMenu.tscn
+++ b/Assets/Utility/UI/LvlUps/CardPopupMenu.tscn
@@ -4,18 +4,17 @@
 
 [node name="CardPopupMenu" type="CanvasLayer"]
 process_mode = 3
+visible = false
 script = ExtResource("1_rdosj")
 
-[node name="MarginContainer" type="MarginContainer" parent="."]
+[node name="MarginContainer" type="VBoxContainer" parent="."]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_constants/margin_left = 8
-theme_override_constants/margin_top = 8
-theme_override_constants/margin_right = 8
-theme_override_constants/margin_bottom = 8
+theme_override_constants/separation = 16
+alignment = 1
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer"]
 layout_mode = 2
@@ -23,3 +22,11 @@ size_flags_horizontal = 4
 size_flags_vertical = 4
 theme_override_constants/separation = 10
 alignment = 1
+
+[node name="Button" type="Button" parent="MarginContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+text = "Reroll"
+
+[connection signal="pressed" from="MarginContainer/Button" to="." method="_on_button_pressed"]

--- a/Assets/Utility/UI/LvlUps/CardPopupMenu.tscn
+++ b/Assets/Utility/UI/LvlUps/CardPopupMenu.tscn
@@ -23,10 +23,11 @@ size_flags_vertical = 4
 theme_override_constants/separation = 10
 alignment = 1
 
-[node name="Button" type="Button" parent="MarginContainer"]
+[node name="RerollButton" type="Button" parent="MarginContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
 text = "Reroll"
 
-[connection signal="pressed" from="MarginContainer/Button" to="." method="_on_button_pressed"]
+[connection signal="pressed" from="MarginContainer/RerollButton" to="." method="_on_reroll_button_pressed"]


### PR DESCRIPTION
### Reroll upgrade ability has been added

![image](https://github.com/AGH-Code-Industry/monstrous-tide/assets/60001858/d85a9450-7d47-4bed-ab64-ed085d2378ec)


Fom now, upgrade menu has new button called "Reroll". When button is clicked, current cards in deck are removed and new cards are being drawn.

Reroll logic is quite copmlicated because there are many different scenarios that require different behaviors. For example: When clicking reroll we don't wanna get old upgrades, but if in our deck has 3 cards and there are 5 cards in total - one card from current deck must be drawn again.