### PR TITLE
fixed bug

### DIFF
--- a/Assets/Player/Stats/stat.gd
+++ b/Assets/Player/Stats/stat.gd
@@ -1,6 +1,7 @@
 class_name Stat extends Resource
 
 enum Type{
+	UNDEFINED = 0,
 	#Offensive
 	DAMAGE = 100,
 	ATTACKSPEED = 105,


### PR DESCRIPTION
Enums in Godot work a bit strange, when setting it from editor they got the correct name but not value. Because of this, when new stat was created, and type wasn't changed from damage it value was wrong and didn't add correctly. Now it requires to change stat type which fixes the issue.